### PR TITLE
fix: restore client list object fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Restored client lists across the application: the protected client query can again read the three non-sensitive object location fields it embeds. Client phone numbers, media, and other restricted object data remain protected.
+
 ## [1.0.3] - 2026-07-20
 
 ### Added

--- a/supabase/migrations/20260720103000_restore_client_list_object_fields.sql
+++ b/supabase/migrations/20260720103000_restore_client_list_object_fields.sql
@@ -1,0 +1,6 @@
+-- The client list embeds non-sensitive location fields from client_objects.
+-- Keep direct access limited to only the fields required by that read path;
+-- phone, media and internal notes remain unavailable to authenticated users.
+grant select (geo_lat, geo_lng, location_mode)
+on table public.client_objects
+to authenticated;


### PR DESCRIPTION
## Что изменено

- добавлена миграция с точечным `SELECT` только для `geo_lat`, `geo_lng` и `location_mode` таблицы `client_objects`;
- обновлён changelog;
- телефон, медиа и внутренние заметки не открываются.

## Зачем

Защищённый запрос списков клиентов встраивает эти три неопасных поля объекта. После ужесточения прав запрос потерял доступ к ним, из-за чего списки клиентов перестали загружаться.

## Проверка

- `git diff --cached --check` перед коммитом;
- миграция использует column-level grant и не расширяет доступ к чувствительным полям.